### PR TITLE
Proxy requests to /graphql to localhost:4000/graphql

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@types/react": "^17.0.20",
     "@types/react-dom": "^17.0.9",
     "graphql": "^16.3.0",
+    "http-proxy-middleware": "^2.0.4",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-scripts": "5.0.0",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -13,7 +13,7 @@ import {
 
 
 const client = new ApolloClient({
-  uri: 'http://localhost:4000/graphql',
+  uri: 'https://cring.info/graphql',
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,11 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function(app) {
+  app.use(
+    '/graphql',
+    createProxyMiddleware({
+      target: 'http://localhost:4000/graphql',
+      changeOrigin: true,
+    })
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -5985,7 +5985,7 @@ http-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz#03af0f4676d172ae775cb5c33f592f40e1a4e07a"
   integrity sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==


### PR DESCRIPTION
Still need a solution for deciding the target of the ApolloClient in src/index.tsx. Right now its set to cring.info which will break in dev