### PR TITLE
Improve backend start times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ node_modules
 
 # production
 frontend/build
+backend/typeDefs.js
+backend/resolvers.js
+backend/app.js
+backend/generated/graphql.js
 
 # misc
 .DS_Store

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,9 +17,8 @@
   },
   "scripts": {
     "start": "ts-node-dev app.ts",
-    "prestart:prod": "yarn build",
-    "start:prod": "node app.js",
-    "build": "tsc ./app.ts",
+    "start:prod": "ts-node --transpile-only app.js",
+    "build": "tsc --build ./app.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "generate": "graphql-codegen --config codegen.yml"
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -16,7 +16,10 @@
     "typescript": "^4.6.3"
   },
   "scripts": {
-    "dev": "ts-node-dev app.ts",
+    "start": "ts-node-dev app.ts",
+    "prestart:prod": "yarn build",
+    "start:prod": "node app.js",
+    "build": "tsc ./app.ts",
     "test": "echo \"Error: no test specified\" && exit 1",
     "generate": "graphql-codegen --config codegen.yml"
   },

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "NODE_ENV=development yarn --cwd backend dev & yarn --cwd frontend start",
-    "start:prod": "NODE_ENV=production yarn --cwd backend dev",
-    "build": "yarn --cwd frontend build",
+    "start": "NODE_ENV=development yarn --cwd backend start & yarn --cwd frontend start",
+    "start:prod": "NODE_ENV=production yarn --cwd backend start:prod",
+    "build": "yarn --cwd frontend build && yarn --cwd backend build",
     "generate": "yarn --cwd frontend generate && yarn --cwd backend generate"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "scripts": {
     "start": "NODE_ENV=development yarn --cwd backend start & yarn --cwd frontend start",
+    "prestart:prod": "yarn",
     "start:prod": "NODE_ENV=production yarn --cwd backend start:prod",
     "build": "yarn --cwd frontend build && yarn --cwd backend build",
     "generate": "yarn --cwd frontend generate && yarn --cwd backend generate"


### PR DESCRIPTION
Switched to ``` ts-node --transpile-only app.ts ``` for serving the backend which skips type checking during runtime. It's not optimal, but #31 is getting in the way. Also fixed the names of each start command to be more uniform throughout the project. Finally made sure we're always updating dependencies before launching into production from the main directory.